### PR TITLE
Feature/add screen fraction move

### DIFF
--- a/config.h
+++ b/config.h
@@ -31,9 +31,9 @@ static FractionBinding fraction_bindings[] = {
     /* key  fractor x  fractor y */
     { XK_c,         2,         2 },
     { XK_x,         4,         4 },
-    { XK_v,         1.25,      4 },
-    { XK_m,         4,         1.25 },
-    { XK_comma,     1.25,      1.25 },
+    { XK_v,         1.33,      4 },
+    { XK_m,         4,         1.33 },
+    { XK_comma,     1.33,      1.33 },
 };
 
 /* 1: left
@@ -63,7 +63,6 @@ static ScrollBinding scroll_bindings[] = {
 static ShellBinding shell_bindings[] = {
     /* key         command */
     { XK_0,        "xdotool mousemove 0 0" },
-    { XK_1,        "xdotool mousemove 960 540" },
 };
 
 /* exits on key release which allows click and exit with one key */

--- a/config.h
+++ b/config.h
@@ -26,6 +26,12 @@ static MoveBinding move_bindings[] = {
     { XK_j,         0,     1 },
 };
 
+/* moves the mouse pointer to the center */
+static CenterBinding center_bindings[] = {
+    /* key */
+    { XK_c },
+};
+
 /* 1: left
  * 2: middle
  * 3: right */
@@ -53,7 +59,7 @@ static ScrollBinding scroll_bindings[] = {
 static ShellBinding shell_bindings[] = {
     /* key         command */
     { XK_0,        "xdotool mousemove 0 0" },
-    { XK_c,        "xdotool mousemove 960 540" },
+    { XK_1,        "xdotool mousemove 960 540" },
 };
 
 /* exits on key release which allows click and exit with one key */

--- a/config.h
+++ b/config.h
@@ -26,10 +26,14 @@ static MoveBinding move_bindings[] = {
     { XK_j,         0,     1 },
 };
 
-/* moves the mouse pointer to the center */
-static CenterBinding center_bindings[] = {
-    /* key */
-    { XK_c },
+/* moves the mouse pointer to screen fraction position */
+static FractionBinding fraction_bindings[] = {
+    /* key  fractor x  fractor y */
+    { XK_c,         2,         2 },
+    { XK_x,         4,         4 },
+    { XK_v,         1.25,      4 },
+    { XK_m,         4,         1.25 },
+    { XK_comma,     1.25,      1.25 },
 };
 
 /* 1: left

--- a/xmouseless.c
+++ b/xmouseless.c
@@ -22,7 +22,9 @@ typedef struct {
 
 typedef struct {
     KeySym keysym;
-} CenterBinding;
+    float x;
+    float y;
+} FractionBinding;
 
 typedef struct {
     KeySym keysym;
@@ -212,12 +214,11 @@ void handle_key(KeyCode keycode, Bool is_press) {
         }
     }
 
-    /* center bindings */
-    for (i = 0; i < LENGTH(center_bindings); i++) {
-        if (center_bindings[i].keysym == keysym) {
-            int sign = is_press ? 1 : -1;
-            move_absolute((float) width / 2,
-                          (float) height / 2);
+    /* fraction bindings */
+    for (i = 0; i < LENGTH(fraction_bindings); i++) {
+        if (fraction_bindings[i].keysym == keysym) {
+            move_absolute((float) width / fraction_bindings[i].x,
+                          (float) height / fraction_bindings[i].y);
         }
     }
 

--- a/xmouseless.c
+++ b/xmouseless.c
@@ -147,6 +147,7 @@ void scroll(float x, float y) {
 void init_x() {
     int i;
     int screen;
+
     /* initialize support for concurrent threads */
     XInitThreads();
 


### PR DESCRIPTION
A more enhanced function to move the cursors position in screen fractions, e.g, screen center and center of each screen quadrant:

- screen center: XK_c
- upper left: XK_x,
- upper right: XK_v,
- lower left: XK_m,
- lower right: XK_comma

The screen fractions may be overwritten in the config.h by specifying the keybinding and divider for x, y axes.